### PR TITLE
Locking

### DIFF
--- a/Wordle/Board/BoardCell.swift
+++ b/Wordle/Board/BoardCell.swift
@@ -18,6 +18,8 @@ class BoardCell: UICollectionViewCell {
         return view
     }()
 
+    var locked: Bool = false
+
     //MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -37,5 +39,14 @@ class BoardCell: UICollectionViewCell {
 
     private func setupLayout() {
         letter.addConstraint(topAnchor: topAnchor, leadingAnchor: leadingAnchor, trailingAnchor: trailingAnchor, bottomAnchor: bottomAnchor, paddingTop: 0.0, paddingLeft: 0.0, paddingRight: 0.0, paddingBottom: 0.0, width: 0.0, height: 0.0)
+    }
+
+    //MARK: - Methods
+    func setLock(to lockStatus: Bool) {
+        locked = lockStatus
+    }
+
+    func isLocked() -> Bool {
+        return locked
     }
 }

--- a/Wordle/Board/BoardViewController.swift
+++ b/Wordle/Board/BoardViewController.swift
@@ -41,6 +41,12 @@ class BoardViewController: UIViewController, UICollectionViewDelegate, UICollect
 
     private func setupView() {
         view.addSubview(keyboardView)
+        lockRow(row: 1)
+        lockRow(row: 2)
+        lockRow(row: 3)
+        lockRow(row: 4)
+        lockRow(row: 5)
+        lockRow(row: 6)
     }
 
     private func setupLayout() {
@@ -70,7 +76,6 @@ class BoardViewController: UIViewController, UICollectionViewDelegate, UICollect
                                                       for: indexPath) as! BoardCell
         cell.isUserInteractionEnabled = true
         cell.letter.addShadow()
-        cell.letter.animateFlip()
 
         return cell
     }
@@ -107,5 +112,17 @@ class BoardViewController: UIViewController, UICollectionViewDelegate, UICollect
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return CGSize(width: Screen.width, height: 60.0)
+    }
+
+    //MARK: - Custom methods
+    func lockRow(row: Int) {
+        let lowerLimit = (row * 5) - 5
+        let upperLimit = (row * 5) - 1
+
+        print("locking cells: \(lowerLimit) to \(upperLimit)")
+    }
+
+    func rowLocked(row: Int) -> Bool {
+        return false
     }
 }

--- a/Wordle/Extensions/UIFont.swift
+++ b/Wordle/Extensions/UIFont.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIFont {
-    func withTraits(traits:UIFontDescriptor.SymbolicTraits) -> UIFont {
+    func withTraits(traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
         let descriptor = fontDescriptor.withSymbolicTraits(traits)
         return UIFont(descriptor: descriptor!, size: 0)
     }

--- a/Wordle/Keyboard/KeyboardView.swift
+++ b/Wordle/Keyboard/KeyboardView.swift
@@ -50,12 +50,10 @@ class KeyboardView: UIView, UICollectionViewDelegate, UICollectionViewDataSource
 
     //MARK: - CollectionView Delegates
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        print("number of sections: \(keyboardLayers.count)")
         return keyboardLayers.count
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        print("number of items in section: \(keyboardLayers[section].count)")
         return keyboardLayers[section].count
     }
 


### PR DESCRIPTION
Stub in locking methods for the row level.  This will prevent rows that have guesses "locked" in from being deleted when the user taps the backspace button.

Changes to be committed:
	modified:   Wordle/Board/BoardCell.swift
	modified:   Wordle/Board/BoardViewController.swift
	modified:   Wordle/Extensions/UIFont.swift
	modified:   Wordle/Keyboard/KeyboardView.swift